### PR TITLE
Updates RHEL repo link

### DIFF
--- a/DOCS/NOTES.txt
+++ b/DOCS/NOTES.txt
@@ -35,7 +35,7 @@ yum install https://rdoproject.org/repos/rdo-release.rpm
 
 Install EPEL:
 
-yum -y install http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 After installing RDO Newton and EPEL Repos, do a full update and reboot if necessary (new kernel installed):
 


### PR DESCRIPTION
Turns out the installation issues I was facing in Issue #3  was because I was using an incorrect EPEL repo. The problem is that the repo link mentioned in DOCS is not working and I installed an incorrect one from somewhere else. See below, the link mentioned in DOCS gives a 404 error. I updated the link with the one on fedoraproject website and the installation went very smoothly.  
```
$ wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm

--2017-12-04 20:18:30--  http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
Resolving dl.fedoraproject.org (dl.fedoraproject.org)... 209.132.181.24, 209.132.181.23, 209.132.181.25
Connecting to dl.fedoraproject.org (dl.fedoraproject.org)|209.132.181.24|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2017-12-04 20:18:30 ERROR 404: Not Found.
```
I have updated the link in the PR. 